### PR TITLE
Updated acid liquid shader

### DIFF
--- a/Assets/Code/Shaders/Traps/AcidLiquid.shadergraph
+++ b/Assets/Code/Shaders/Traps/AcidLiquid.shadergraph
@@ -64,9 +64,6 @@
             "m_Id": "f1e85c9e3aeb402e9be79cfe59bcf5c7"
         },
         {
-            "m_Id": "0e017a9509754a6d8bb90a7c089e26b1"
-        },
-        {
             "m_Id": "1cc0e7c2899245508a3eef3f4d1d939f"
         },
         {
@@ -149,6 +146,9 @@
         },
         {
             "m_Id": "227ad7a3cceb4a878fe40d318b816ae5"
+        },
+        {
+            "m_Id": "cbdca6870da04408b7a67f64920e767e"
         }
     ],
     "m_GroupDatas": [
@@ -195,20 +195,6 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "0e017a9509754a6d8bb90a7c089e26b1"
-                },
-                "m_SlotId": 3
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "590a38fb249c4106a4c59edddb72c87f"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
                     "m_Id": "19c04c10f63945949785a63a5fe2ea6d"
                 },
                 "m_SlotId": 2
@@ -229,9 +215,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "0e017a9509754a6d8bb90a7c089e26b1"
+                    "m_Id": "cbdca6870da04408b7a67f64920e767e"
                 },
-                "m_SlotId": 2
+                "m_SlotId": 1
             }
         },
         {
@@ -524,6 +510,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "35381d9357fa45e7b9c6e9d6ab80ba26"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "cbdca6870da04408b7a67f64920e767e"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "590a38fb249c4106a4c59edddb72c87f"
                 },
                 "m_SlotId": 0
             }
@@ -1024,8 +1024,8 @@
     "m_ObjectId": "0ce74efac9034a318a1aa0bf34eca35c",
     "m_Title": "Adjust the fill line of the acid liquid",
     "m_Position": {
-        "x": -569.5999755859375,
-        "y": 711.2000122070313
+        "x": -583.9999389648438,
+        "y": 711.2001953125
     }
 }
 
@@ -1042,50 +1042,6 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.SmoothstepNode",
-    "m_ObjectId": "0e017a9509754a6d8bb90a7c089e26b1",
-    "m_Group": {
-        "m_Id": "0ce74efac9034a318a1aa0bf34eca35c"
-    },
-    "m_Name": "Smoothstep",
-    "m_DrawState": {
-        "m_Expanded": true,
-        "m_Position": {
-            "serializedVersion": "2",
-            "x": 1181.5999755859375,
-            "y": 771.199951171875,
-            "width": 208.0,
-            "height": 325.60009765625
-        }
-    },
-    "m_Slots": [
-        {
-            "m_Id": "719339f7bf60466f954e5e7fad4dfd71"
-        },
-        {
-            "m_Id": "380dd009a4a44be5a125463e738744f3"
-        },
-        {
-            "m_Id": "b34449e4680d4089a6039abb8582f213"
-        },
-        {
-            "m_Id": "7ebf9ed44e414ea0be4cb5ec5f9bbd92"
-        }
-    ],
-    "synonyms": [
-        "curve"
-    ],
-    "m_Precision": 0,
-    "m_PreviewExpanded": true,
-    "m_DismissedVersion": 0,
-    "m_PreviewMode": 0,
-    "m_CustomColors": {
-        "m_SerializableColors": []
-    }
 }
 
 {
@@ -1848,30 +1804,6 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "380dd009a4a44be5a125463e738744f3",
-    "m_Id": 1,
-    "m_DisplayName": "Edge2",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Edge2",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.5,
-        "y": 1.0,
-        "z": 1.0,
-        "w": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "3f36bc6ecfd04928b7f99d11f5ddf01b",
     "m_Id": 0,
     "m_DisplayName": "A",
@@ -2539,6 +2471,30 @@
 {
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "5f5478bbbf614228a7b022331d1dbc58",
+    "m_Id": 0,
+    "m_DisplayName": "Edge",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Edge",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.5,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
     "m_ObjectId": "6051b4a49f4a4dceb00b1af20af10ee3",
     "m_Id": 2,
     "m_DisplayName": "Out",
@@ -2925,30 +2881,6 @@
 }
 
 {
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "719339f7bf60466f954e5e7fad4dfd71",
-    "m_Id": 0,
-    "m_DisplayName": "Edge1",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Edge1",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.5,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
     "m_ObjectId": "719bdf8caf5b4f3db9e40bb408a5bf9f",
@@ -3119,30 +3051,6 @@
         "y": 1.0,
         "z": 1.0,
         "w": 1.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "7ebf9ed44e414ea0be4cb5ec5f9bbd92",
-    "m_Id": 3,
-    "m_DisplayName": "Out",
-    "m_SlotType": 1,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "Out",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
     },
     "m_DefaultValue": {
         "x": 0.0,
@@ -3618,6 +3526,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "9489ddcdcb0b4d0cb9ea62ebf1d6eb9b",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
     "m_ObjectId": "975e2655c2d64dbf9d239d90e124e471",
     "m_Id": 4,
@@ -3970,30 +3902,6 @@
 
 {
     "m_SGVersion": 0,
-    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
-    "m_ObjectId": "b34449e4680d4089a6039abb8582f213",
-    "m_Id": 2,
-    "m_DisplayName": "In",
-    "m_SlotType": 0,
-    "m_Hidden": false,
-    "m_ShaderOutputName": "In",
-    "m_StageCapability": 3,
-    "m_Value": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    },
-    "m_DefaultValue": {
-        "x": 0.0,
-        "y": 0.0,
-        "z": 0.0,
-        "w": 0.0
-    }
-}
-
-{
-    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector2MaterialSlot",
     "m_ObjectId": "b4ee5ab179d04870a14dd8800838c4a2",
     "m_Id": 6,
@@ -4331,6 +4239,45 @@
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalSpriteLitSubTarget",
     "m_ObjectId": "cbd6caa70569491fa370123b64ad2298"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.StepNode",
+    "m_ObjectId": "cbdca6870da04408b7a67f64920e767e",
+    "m_Group": {
+        "m_Id": "0ce74efac9034a318a1aa0bf34eca35c"
+    },
+    "m_Name": "Step",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1192.800048828125,
+            "y": 798.4000244140625,
+            "width": 208.0001220703125,
+            "height": 301.5999755859375
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "5f5478bbbf614228a7b022331d1dbc58"
+        },
+        {
+            "m_Id": "f62598e97e8b4a6aa69042380001d4ea"
+        },
+        {
+            "m_Id": "9489ddcdcb0b4d0cb9ea62ebf1d6eb9b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -5210,6 +5157,30 @@
     "m_Value": 0.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "f62598e97e8b4a6aa69042380001d4ea",
+    "m_Id": 1,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
 }
 
 {


### PR DESCRIPTION
## Changes:
- Fixed the acid liquid shader division by zero compiler errors

## Updated files:
- AcidLiquid.shadergraph

## Screenshot
![acid liquid distortion](https://github.com/KrillOrBeKrilled/GMTK-2023/assets/66287115/5c03ec94-fd7d-4f4b-bff5-e8440a0816b5)
