### PR TITLE
Preventing new Game Over events after game already ended

### DIFF
--- a/Assets/Code/Scripts/Core/GameManager.cs
+++ b/Assets/Code/Scripts/Core/GameManager.cs
@@ -94,6 +94,8 @@ namespace KrillOrBeKrilled.Core {
         [Tooltip("Tracks when a new scene should be loaded.")]
         public UnityEvent<UnityAction> OnSceneWillChange { get; private set; }
 
+        private bool _isGameOver;
+
         //========================================
         // Unity Methods
         //========================================
@@ -511,6 +513,11 @@ namespace KrillOrBeKrilled.Core {
         /// <param name="endgameMessage"> The message to be displayed on the loss UI. </param>
         /// <remarks> Invokes the <see cref="OnHenLost"/> event. </remarks>
         private void HenLost(string endgameMessage) {
+            if (this._isGameOver) {
+                return;
+            }
+
+            this._isGameOver = true;
             this._playerManager.PlayerController.DisablePlayerInput();
 
             if (this._waveSpawnCoroutine != null) {
@@ -532,6 +539,11 @@ namespace KrillOrBeKrilled.Core {
         /// Otherwise, stops recording the player input and creates a file for the recorded input. </p>
         /// </remarks>
         private void HenWon(string message) {
+            if (this._isGameOver) {
+                return;
+            }
+
+            this._isGameOver = true;
             this.OnHenWon?.Invoke(message);
         }
 


### PR DESCRIPTION
## Changes:
- Added a `bool` flag to indicate when the game is over.
- No more new Game Over events after the game already ended.