### PR TITLE
Bug Fix - Preventing Trap Stacking

### DIFF
--- a/Assets/Code/Scripts/Core/Player/TrapController.cs
+++ b/Assets/Code/Scripts/Core/Player/TrapController.cs
@@ -101,6 +101,8 @@ namespace KrillOrBeKrilled.Core.Player {
             if (!ResourceManager.Instance.CanAffordCost(this.CurrentTrap.Recipe)) {
                 return false;
             }
+            
+            this.InvalidateTrapDeployment();
 
             // Convert the origin tile position to world space
             var deploymentOrigin = this.TrapTilemap.CellToWorld(this._previousTilePositions[0]);


### PR DESCRIPTION
## Changes:
- Spamming the trap deployment button will not allow traps to be built in the exact same place anymore.
-> Immediately invalidates the trap deployment status in the `TrapController` after ensuring that a trap will be instantiated.

## Updated files:
- `TrapController.cs`