### PR TITLE
LoadNextLevel Button fix

### DIFF
--- a/Assets/Code/Scripts/Core/GameManager.cs
+++ b/Assets/Code/Scripts/Core/GameManager.cs
@@ -117,6 +117,7 @@ namespace KrillOrBeKrilled.Core {
             LevelData sourceData = LevelManager.Instance.GetActiveLevelData();
             this._levelData = ScriptableObject.CreateInstance<LevelData>();
             this._levelData.DialogueName = sourceData.DialogueName;
+            this._levelData.NextLevelName = sourceData.NextLevelName;
             this._levelData.Type = sourceData.Type;
             this._levelData.RespawnPositions = sourceData.RespawnPositions.ToList();
             this._levelData.EndgameTargetPosition = sourceData.EndgameTargetPosition;
@@ -208,7 +209,7 @@ namespace KrillOrBeKrilled.Core {
             ResourceSpawner.Instance.StartSpawner();
             this.OnStartLevel?.Invoke();
         }
-        
+
         /// <summary>
         /// Enables player controls and recording features, hero movement, and timed coin earning. To be used to start
         /// the level when no hero actors have been spawned in the dialogue.
@@ -251,7 +252,15 @@ namespace KrillOrBeKrilled.Core {
         public void LoadNextLevel() {
             this._pauseManager.UnpauseGame();
             this._pauseManager.SetIsPausable(false);
-            this.OnSceneWillChange?.Invoke(SceneNavigationManager.Instance.LoadLevelsScene);
+
+            UnityAction onSceneLoaded;
+            if (string.IsNullOrEmpty(this._levelData.NextLevelName)) {
+                onSceneLoaded = SceneNavigationManager.Instance.LoadLevelsScene;
+            } else {
+                onSceneLoaded = () => LevelManager.Instance.LoadLevel(this._levelData.NextLevelName);;
+            }
+
+            this.OnSceneWillChange?.Invoke(onSceneLoaded);
         }
 
         /// <summary>

--- a/Assets/Code/Scripts/Managers/LevelManager.cs
+++ b/Assets/Code/Scripts/Managers/LevelManager.cs
@@ -22,13 +22,13 @@ namespace KrillOrBeKrilled.Managers {
 
         private readonly Dictionary<string, LevelData> _levelDatas = new Dictionary<string, LevelData>();
         private static bool LevelWasLoaded { get; set; } = false;
-        
+
         //========================================
         // Unity Methods
         //========================================
-        
+
         #region Unity Methods
-        
+
         protected override void Awake() {
             base.Awake();
 
@@ -36,15 +36,15 @@ namespace KrillOrBeKrilled.Managers {
                 this._levelDatas[levelData.name] = levelData;
             }
         }
-        
+
         #endregion
-        
+
         //========================================
         // Public Methods
         //========================================
-        
+
         #region Public Methods
-        
+
         /// <summary>
         /// Finds the active <see cref="LevelData"/> to be parsed in the current level.
         /// </summary>
@@ -57,7 +57,7 @@ namespace KrillOrBeKrilled.Managers {
         public LevelData GetActiveLevelData() {
             return LevelWasLoaded ? this._activeLevelData : this._defaultLevelData;
         }
-        
+
         /// <summary>
         /// Copies the <see cref="LevelData"/> associated with the level into a separate <see cref="LevelData"/>
         /// object to persist between scene loads for future parsing, and loads the game scene through the
@@ -77,6 +77,7 @@ namespace KrillOrBeKrilled.Managers {
             // Note: stored data is not preserved between game sessions.
             this._activeLevelData.Type = source.Type;
             this._activeLevelData.DialogueName = source.DialogueName;
+            this._activeLevelData.NextLevelName = source.NextLevelName;
             this._activeLevelData.EndgameTargetPosition = source.EndgameTargetPosition;
             this._activeLevelData.RespawnPositions = source.RespawnPositions.ToList();
             this._activeLevelData.WavesData = new WavesData() { WavesList = source.WavesData.WavesList.ToList() };
@@ -84,7 +85,7 @@ namespace KrillOrBeKrilled.Managers {
             LevelWasLoaded = true;
             SceneNavigationManager.Instance.LoadGameLevelScene(levelName);
         }
-        
+
         #endregion
     }
 }

--- a/Assets/Code/Scripts/Model/LevelData.cs
+++ b/Assets/Code/Scripts/Model/LevelData.cs
@@ -18,6 +18,7 @@ namespace KrillOrBeKrilled.Model {
         [Tooltip("The default level mode is Endless.")]
         public LevelType Type = LevelType.Endless;
         public string DialogueName;
+        public string NextLevelName;
         public Vector3 EndgameTargetPosition = Vector3.zero;
         public List<Vector3> RespawnPositions;
         public WavesData WavesData;

--- a/Assets/Code/Scripts/UI/LevelsUI.cs
+++ b/Assets/Code/Scripts/UI/LevelsUI.cs
@@ -13,51 +13,51 @@ namespace KrillOrBeKrilled.UI {
     /// </summary>
     public class LevelsUI : MonoBehaviour {
         private string _levelNameToLoad;
-        
-        [Tooltip("Used to fade the scene in and out.")] 
+
+        [Tooltip("Used to fade the scene in and out.")]
         [SerializeField] private Image _foreground;
         [Tooltip("Used to cover the scene until the next level loads.")]
         [SerializeField] private Image _loadingScreen;
-        [Tooltip("Used to screen wipe the scene in and out.")] 
+        [Tooltip("Used to screen wipe the scene in and out.")]
         [SerializeField] private ScreenWipeUI _screenWipe;
 
         private const float FadeDuration = 0.5f;
-        
+
         //========================================
         // Unity Methods
         //========================================
-        
+
         #region Unity Methods
-        
+
         private void Awake() {
             this._screenWipe.gameObject.SetActive(false);
-            
+
             this._foreground.gameObject.SetActive(true);
             this._foreground
                 .DOFade(0, FadeDuration)
                 .OnComplete(() => this._foreground.gameObject.SetActive(false));
         }
-        
+
         #endregion
 
         //========================================
         // Public Methods
         //========================================
-        
+
         #region Public Methods
-        
+
         /// <summary>
         /// Plays a screen wipe-in transition effect and sets the level to load upon completion.
         /// </summary>
         /// <param name="levelName"> The name of the level corresponding to the LevelData name. </param>
         public void LoadLevel(string levelName) {
-            _levelNameToLoad = levelName;
-            
+            this._levelNameToLoad = levelName;
+
             this._screenWipe.gameObject.SetActive(true);
             this._screenWipe.SetRandomWipeShape();
-            this._screenWipe.WipeIn(LoadLevelScene);
+            this._screenWipe.WipeIn(this.LoadLevelScene);
         }
-        
+
         /// <summary>
         /// Fades in the screen and loads the MainMenu scene upon completion.
         /// </summary>
@@ -67,24 +67,24 @@ namespace KrillOrBeKrilled.UI {
                 .DOFade(1, FadeDuration)
                 .OnComplete(SceneNavigationManager.Instance.LoadMainMenuScene);
         }
-        
+
         #endregion
-        
+
         //========================================
         // Internal Methods
         //========================================
-        
+
         #region Internal Methods
-        
+
         /// <summary>
         /// Loads the level corresponding to <see cref="_levelNameToLoad"/>.
         /// </summary>
         /// <remarks> Triggered by <see cref="ScreenWipeUI.WipeIn"/> upon completion. </remarks>
         internal void LoadLevelScene() {
             this._loadingScreen.gameObject.SetActive(true);
-            LevelManager.Instance.LoadLevel(_levelNameToLoad);
+            LevelManager.Instance.LoadLevel(this._levelNameToLoad);
         }
-        
+
         #endregion
     }
 }

--- a/Assets/Data/Levels/Story_001.asset
+++ b/Assets/Data/Levels/Story_001.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Type: 0
   DialogueName: TutorialDialogue
+  NextLevelName: Story_002
   EndgameTargetPosition: {x: 248, y: -0.5, z: 0}
   RespawnPositions:
   - {x: -8.05, y: -0.39, z: 0}

--- a/Assets/Data/Levels/Story_002.asset
+++ b/Assets/Data/Levels/Story_002.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Type: 0
   DialogueName: Level2Dialogue
+  NextLevelName: Story_003
   EndgameTargetPosition: {x: 285, y: -0.5, z: 0}
   RespawnPositions:
   - {x: -8.05, y: -0.39, z: 0}


### PR DESCRIPTION
## Changes:
- Added a new field for the `LevelData` files: `NextLevelName`.
- Updated code to load the next level when there is a `NextLevelName` field.
  - If `NextLevelName` is empty or null - defaults to loading the `Levels` scene