### PR TITLE
Freezing heroes and stopping spawn on game over

### DIFF
--- a/Assets/Code/Scripts/Core/GameManager.cs
+++ b/Assets/Code/Scripts/Core/GameManager.cs
@@ -10,6 +10,7 @@ using KrillOrBeKrilled.Managers;
 using KrillOrBeKrilled.Model;
 using KrillOrBeKrilled.Traps;
 using KrillOrBeKrilled.UGSAnalytics;
+using System;
 using UnityEngine;
 using UnityEngine.Events;
 using Yarn.Unity;
@@ -419,6 +420,10 @@ namespace KrillOrBeKrilled.Core {
             foreach (HeroData heroData in waveData.Heroes) {
                 this.SpawnHero(heroData);
                 yield return new WaitForSeconds(waveData.HeroSpawnDelayInSeconds);
+
+                if (this._isGameOver) {
+                    yield break;
+                }
             }
 
             if (waveData.NextWaveSpawnDelayInSeconds < 0) {
@@ -554,7 +559,7 @@ namespace KrillOrBeKrilled.Core {
                 this.StopCoroutine(this._waveSpawnCoroutine);
             }
 
-            this.StopAllHeroes();
+            this.FreezeAllHeroes();
             this.OnHenLost?.Invoke(endgameMessage);
             EventManager.Instance.GameOverEvent?.Invoke();
         }
@@ -591,6 +596,24 @@ namespace KrillOrBeKrilled.Core {
         private void StopAllHeroes() {
             foreach (var hero in this._heroes) {
                 hero.StopRunning();
+            }
+        }
+
+        /// <summary>
+        /// Freezes all heroes in the level.
+        /// </summary>
+        private void FreezeAllHeroes() {
+            foreach (Hero hero in this._heroes) {
+                hero.Freeze();
+            }
+        }
+
+        /// <summary>
+        /// Unfreezes all heroes in the level.
+        /// </summary>
+        private void UnfreezeAllHeroes() {
+            foreach (Hero hero in this._heroes) {
+                hero.Unfreeze();
             }
         }
 

--- a/Assets/Code/Scripts/Core/GameManager.cs
+++ b/Assets/Code/Scripts/Core/GameManager.cs
@@ -10,7 +10,6 @@ using KrillOrBeKrilled.Managers;
 using KrillOrBeKrilled.Model;
 using KrillOrBeKrilled.Traps;
 using KrillOrBeKrilled.UGSAnalytics;
-using System;
 using UnityEngine;
 using UnityEngine.Events;
 using Yarn.Unity;
@@ -434,7 +433,7 @@ namespace KrillOrBeKrilled.Core {
             if (this._isGameOver) {
                 yield break;
             }
-            
+
             this._waveSpawnCoroutine = this.SpawnNextWave();
             yield return this._waveSpawnCoroutine;
         }

--- a/Assets/Code/Scripts/Core/GameManager.cs
+++ b/Assets/Code/Scripts/Core/GameManager.cs
@@ -431,6 +431,10 @@ namespace KrillOrBeKrilled.Core {
             }
 
             yield return new WaitForSeconds(waveData.NextWaveSpawnDelayInSeconds);
+            if (this._isGameOver) {
+                yield break;
+            }
+            
             this._waveSpawnCoroutine = this.SpawnNextWave();
             yield return this._waveSpawnCoroutine;
         }

--- a/Assets/Code/Scripts/Heroes/AI/Basic/BasicBT.cs
+++ b/Assets/Code/Scripts/Heroes/AI/Basic/BasicBT.cs
@@ -23,7 +23,7 @@ namespace KrillOrBeKrilled.Heroes.AI {
         [Range(0, 7)]
         [SerializeField] internal float MovementSpeed = 4f;
         [SerializeField] internal float SpeedBlendDuration = 0.5f;
-        
+
         // ---------------- Jumping ------------------
         [Header("Jumps")]
         [SerializeField] internal float MinJumpForce = 0f;
@@ -31,7 +31,7 @@ namespace KrillOrBeKrilled.Heroes.AI {
 
         protected override Node SetupTree() {
             var heroTransform = this.transform;
-            
+
             var jumping = new Sequence(new List<Node> {
                 new LookForObstacle(),
                 new ApproachTarget(heroTransform, this.Rigidbody, this.AnimController, this.MovementSpeed, this.SpeedBlendDuration),
@@ -43,22 +43,24 @@ namespace KrillOrBeKrilled.Heroes.AI {
                 new Fall(heroTransform, this.Rigidbody, this.AnimController, this.GroundToSight),
                 jumping
             });
-                
+
             var groundJumping = new Sequence(new List<Node> {
                 new LookForGround(heroTransform, this.HeroSight, this.GroundToSight, this.ObstaclesToSight),
                 jumpAndFall
             });
-            
+
             var root = new Selector(new List<Node> {
+                new Freeze(this.Rigidbody, this.AnimController),
                 new Stun(),
                 groundJumping,
                 new Run(this.Rigidbody, this.AnimController, this.MovementSpeed),
                 new Idle(this.Rigidbody, this.AnimController)
             });
-            
+
             root.SetData("JumpKey", this.JumpKey);
             root.SetData("XSpeedKey", this.XSpeedKey);
             root.SetData("YSpeedKey", this.YSpeedKey);
+            root.SetData("IsFrozen", false);
             root.SetData("IsMoving", true);
             root.SetData("IsStunned", false);
             root.SetData("StunDuration", 0f);
@@ -66,9 +68,9 @@ namespace KrillOrBeKrilled.Heroes.AI {
 
             jumping.SetData("JumpLaunchPoint", Vector3.zero);
             jumping.SetData("JumpVelocity", Vector3.zero);
-            
+
             jumpAndFall.SetData("JumpLandPoint", Vector3.zero);
-            
+
             groundJumping.SetData("PitList", new List<(Vector3, Vector3)>());
             groundJumping.SetData("IsFalling", false);
 

--- a/Assets/Code/Scripts/Heroes/AI/Basic/Tasks/Freeze.cs
+++ b/Assets/Code/Scripts/Heroes/AI/Basic/Tasks/Freeze.cs
@@ -1,0 +1,40 @@
+using KrillOrBeKrilled.Heroes.BehaviourTree;
+using UnityEngine;
+
+//*******************************************************************************************
+// Stun
+//*******************************************************************************************
+namespace KrillOrBeKrilled.Heroes.AI {
+    /// <summary>
+    /// A task node used to operate the hero AI that governs the hero's Freeze logic.
+    /// Freezes hero in place, used when the game has ended.
+    /// </summary>
+    public class Freeze : Node {
+        private readonly Rigidbody2D _rigidbody;
+        private readonly Animator _animController;
+
+        public Freeze(Rigidbody2D rigidbody, Animator animController) {
+            this._rigidbody = rigidbody;
+            this._animController = animController;
+        }
+
+        /// <summary>
+        /// A task node used to operate the hero AI that governs the hero's Freeze logic.
+        /// Freezes hero in place, used when the game has ended.
+        /// </summary>
+        /// <returns> The <b>success</b> status if "IsFrozen" data is set. </returns>
+        internal override NodeStatus Evaluate() {
+            if (!(bool)this.GetData("IsFrozen")) {
+                this._rigidbody.isKinematic = false;
+                return NodeStatus.FAILURE;
+            }
+
+            this._rigidbody.isKinematic = true;
+            this._rigidbody.velocity = Vector2.zero;
+            this._animController.SetFloat((int)this.GetData("XSpeedKey"), Mathf.Abs(this._rigidbody.velocity.x));
+            this._animController.SetFloat((int)this.GetData("YSpeedKey"), Mathf.Abs(this._rigidbody.velocity.y));
+
+            return NodeStatus.SUCCESS;
+        }
+    }
+}

--- a/Assets/Code/Scripts/Heroes/AI/Basic/Tasks/Freeze.cs.meta
+++ b/Assets/Code/Scripts/Heroes/AI/Basic/Tasks/Freeze.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b2b9e1864f2a4c77bc9d3f46054fc48e
+timeCreated: 1702230565

--- a/Assets/Code/Scripts/Heroes/Hero.cs
+++ b/Assets/Code/Scripts/Heroes/Hero.cs
@@ -20,7 +20,7 @@ namespace KrillOrBeKrilled.Heroes {
         private Rigidbody2D _rigidbody;
         private HeroBT _heroBrain;
         private FieldOfView _heroSight;
-        
+
         private const int CoinsEarnedOnDeath = 2;
 
         // ----------------- Health ------------------
@@ -29,7 +29,7 @@ namespace KrillOrBeKrilled.Heroes {
 
         // ----------------- Data --------------------
         public HeroData.HeroType Type { get; private set; }
-        
+
         // ------------- Sound Effects ---------------
         private HeroSoundsController _soundsController;
 
@@ -39,32 +39,32 @@ namespace KrillOrBeKrilled.Heroes {
 
         [Tooltip("Tracks when the hero dies.")]
         public UnityEvent<Hero> OnHeroDied;
-        
+
         // This is added temporarily to deal with dependencies problem.
         public static event Action<HeroData.HeroType, Transform> OnHeroDeath;
 
         //========================================
         // Unity Methods
         //========================================
-        
+
         #region Unity Methods
-        
+
         private void Awake() {
             this.TryGetComponent(out this._rigidbody);
             this.TryGetComponent(out this._heroBrain);
             this.TryGetComponent(out this._heroSight);
         }
-        
+
         #endregion
-        
+
         //========================================
         // Public Methods
         //========================================
-        
+
         #region Public Methods
-        
+
         #region IDamageable Implementations
-        
+
         /// <summary>
         /// Reduces the hero's movement speed by a percentage reduction via the <see cref="HeroBT"/>.
         /// </summary>
@@ -73,7 +73,7 @@ namespace KrillOrBeKrilled.Heroes {
         public void ApplySpeedPenalty(float penalty) {
             this._heroBrain.UpdateData("SpeedPenalty", Mathf.Clamp(penalty, 0f, 1f));
         }
-        
+
         /// <summary>
         /// Decrements the hero's number of lives, playing associated SFX. If the number of lives are
         /// reduced to zero, broadcasts the endgame and destroys this GameObject. Otherwise, respawns
@@ -89,18 +89,18 @@ namespace KrillOrBeKrilled.Heroes {
             OnHeroDeath?.Invoke(this.Type, this.transform);
             Destroy(this.gameObject);
         }
-        
+
         public int GetHealth() {
             return this.Health;
         }
-        
+
         /// <summary>
         /// Resets the speed penalty to return the hero movement speed to normal via the <see cref="HeroBT"/>.
         /// </summary>
         public void ResetSpeedPenalty() {
             this._heroBrain.UpdateData("SpeedPenalty", 0f);
         }
-        
+
         /// <summary>
         /// Decrements the hero's health, earns coins through the <see cref="CoinManager"/>,
         /// and plays associated SFX. If the health falls to zero or below, triggers the hero death.
@@ -125,11 +125,11 @@ namespace KrillOrBeKrilled.Heroes {
         public void ThrowActorBack(float stunDuration, float throwForce) {
             this._heroBrain.UpdateData("IsStunned", true);
             this._heroBrain.UpdateData("StunDuration", stunDuration);
-            
+
             Vector2 explosionVector = new Vector2(-1f, 0.7f) * throwForce;
             this._rigidbody.AddForce(explosionVector, ForceMode2D.Impulse);
         }
-        
+
         public void ThrowActorForward(float throwForce) {
             this._rigidbody.velocity = Vector2.zero;
             Vector2 leapVector = new Vector2(0.19f, 2f) * throwForce;
@@ -137,14 +137,14 @@ namespace KrillOrBeKrilled.Heroes {
         }
 
         #endregion
-        
+
         /// <summary>
         /// Enables movement until the hero enters the level.
         /// </summary>
         public void EnterLevel() {
             this.StartCoroutine(this.EnterLevelAnimation());
         }
-        
+
         public void Initialize(HeroData heroData, HeroSoundsController soundsController, Tilemap groundTilemap) {
             this.Health = heroData.Health;
             this.Type = heroData.Type;
@@ -153,7 +153,7 @@ namespace KrillOrBeKrilled.Heroes {
             this._heroBrain.Initialize(soundsController);
             this._heroSight.Initialize(groundTilemap);
         }
-        
+
         /// <summary>
         /// Enables movement through the <see cref="HeroBT"/>.
         /// </summary>
@@ -161,22 +161,36 @@ namespace KrillOrBeKrilled.Heroes {
             this.StopAllCoroutines();
             this._heroBrain.UpdateData("IsMoving", true);
         }
-        
+
         /// <summary>
         /// Disables movement through the <see cref="HeroBT"/>.
         /// </summary>
         public void StopRunning() {
             this._heroBrain.UpdateData("IsMoving", false);
         }
-        
+
+        /// <summary>
+        /// Freeze this hero. No actions will be performed.
+        /// </summary>
+        public void Freeze() {
+            this._heroBrain.UpdateData("IsFrozen", true);
+        }
+
+        /// <summary>
+        /// Unfreeze this hero. Resume BT.
+        /// </summary>
+        public void Unfreeze() {
+            this._heroBrain.UpdateData("IsFrozen", false);
+        }
+
         #endregion
 
         //========================================
         // Private Methods
         //========================================
-        
+
         #region Private Methods
-        
+
         /// <summary>
         /// Enables movement through the <see cref="HeroBT"/> for a duration of time and then disables
         /// movement.
@@ -186,10 +200,10 @@ namespace KrillOrBeKrilled.Heroes {
             this._heroBrain.UpdateData("IsMoving", true);
 
             yield return new WaitForSeconds(2f);
-            
+
             this._heroBrain.UpdateData("IsMoving", false);
         }
-        
+
         #endregion
     }
 }

--- a/Heroes.csproj.DotSettings
+++ b/Heroes.csproj.DotSettings
@@ -1,3 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Ccode/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Ccode_005Cscripts/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Ccode_005Cscripts/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Ccode_005Cscripts_005Cheroes_005Cai_005Cbasic/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Ccode_005Cscripts_005Cheroes_005Cai_005Cbasic_005Cchecks/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Ccode_005Cscripts_005Cheroes_005Cai_005Cbasic_005Ctasks/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## Changes:
- Added `Freeze` node, stops physics on the Hero and sets velocity to 0.
- Freezing heroes on the game end.
- Stopping new waves from being spawned if the game is over.

## Recordings:

- Before, bug:

https://github.com/KrillOrBeKrilled/GMTK-2023/assets/16372290/aa596706-20b3-43fa-acac-0b295ceeccbd

- Fixed:

https://github.com/KrillOrBeKrilled/GMTK-2023/assets/16372290/74e60488-0115-4b15-97cb-eeaa64f77da4

