### PR TITLE
Bug Fix - Initial Selected Trap Highlighter

### DIFF
--- a/Assets/Code/Scripts/Core/Input/PlayerController.cs
+++ b/Assets/Code/Scripts/Core/Input/PlayerController.cs
@@ -65,7 +65,7 @@ namespace KrillOrBeKrilled.Core.Input {
         /// </summary>
         /// <param name="gameManager"> Provides major game state-related events to subscribe the entities to. </param>
         internal void Initialize(GameManager gameManager) {
-            Player.Initialize(gameManager.OnHenWon, this.GatherInput);
+            StartCoroutine(Player.Initialize(gameManager.OnHenWon, this.GatherInput));
             TrapController.Initialize(ResourceManager.Instance.CanAffordCost);
         }
         

--- a/Assets/Code/Scripts/Player/PlayerCharacter.cs
+++ b/Assets/Code/Scripts/Player/PlayerCharacter.cs
@@ -328,11 +328,14 @@ namespace KrillOrBeKrilled.Player {
         /// <param name="onHenWon"> An event to notify listeners when a level has been completed. </param>
         /// <param name="getControllerInput"> A delegate callback used to fetch input from the controller that
         /// possesses this player entity. </param>
-        public void Initialize(UnityEvent<string> onHenWon, InputDelegate<float, bool, bool> getControllerInput) {
+        public IEnumerator Initialize(UnityEvent<string> onHenWon, InputDelegate<float, bool, bool> getControllerInput) {
             this._gatherControllerInput = getControllerInput;
             
             onHenWon.AddListener(this.GameOver);
 
+            // Wait for a frame to let the UI setup finish before globally broadcasting the initial selected trap.
+            yield return null;
+            
             this.OnSelectedTrapChanged?.Invoke(this._trapController.CurrentTrap);
         }
 


### PR DESCRIPTION
## Changes:
- Adjusted the PlayerCharacter initializer method to wait a frame before broadcasting the initial trap selected value to listeners to allow the UI setup to completely finish beforehand and properly receive the data