### PR TITLE
Basic Respawn

### DIFF
--- a/Assets/Code/Scripts/Environment/FallCollider.cs
+++ b/Assets/Code/Scripts/Environment/FallCollider.cs
@@ -22,7 +22,7 @@ namespace KrillOrBeKrilled.Environment {
 
         private void OnTriggerEnter2D(Collider2D other) {
             if (other.TryGetComponent(out IDamageable actor)) {
-                actor.Die();
+                actor.Die(IDamageable.DamageSource.Fall);
             }
 
             if (other.gameObject.layer == LayerMask.NameToLayer("Pickups")) {

--- a/Assets/Code/Scripts/Heroes/Hero.cs
+++ b/Assets/Code/Scripts/Heroes/Hero.cs
@@ -76,10 +76,11 @@ namespace KrillOrBeKrilled.Heroes {
         /// reduced to zero, broadcasts the endgame and destroys this GameObject. Otherwise, respawns
         /// the hero.
         /// </summary>
+        /// <param name="damageSource"></param>
         /// <remarks>
         /// Invokes the <see cref="OnHeroDied"/> event.
         /// </remarks>
-        public void Die() {
+        public void Die(IDamageable.DamageSource damageSource) {
             this._soundsController.OnHeroDeath();
 
             this.OnHeroDied?.Invoke(this);
@@ -94,7 +95,7 @@ namespace KrillOrBeKrilled.Heroes {
             this.OnHealthChanged?.Invoke(this.Health);
 
             if (this.Health <= 0) {
-                this.Die();
+                this.Die(IDamageable.DamageSource.Trap);
             }
         }
 
@@ -118,7 +119,7 @@ namespace KrillOrBeKrilled.Heroes {
             this.OnHealthChanged?.Invoke(this.Health);
 
             if (this.Health <= 0) {
-                this.Die();
+                this.Die(IDamageable.DamageSource.Trap);
             }
             
             // TODO: Trap reference can be used to alter the durability and other stats

--- a/Assets/Code/Scripts/Interfaces/IDamageable.cs
+++ b/Assets/Code/Scripts/Interfaces/IDamageable.cs
@@ -7,17 +7,24 @@ namespace KrillOrBeKrilled.Interfaces {
     /// Encapsulates all logic associated with actors taking damage, debuffs, and dying.
     /// </summary>
     public interface IDamageable {
+
+        public enum DamageSource {
+            Trap,
+            Hero,
+            Fall
+        }
         
         //========================================
         // Public Methods
         //========================================
         
         #region Public Methods
-        
+
         /// <summary>
         /// Defeats the actor, disabling all controls and playing associated animations before destroying the actor.
         /// </summary>
-        public void Die();
+        /// <param name="damageSource"></param>
+        public void Die(DamageSource damageSource);
         
         /// <summary>
         /// Deals damage to the actor.


### PR DESCRIPTION
## Changes:
- Added basic respawn system.
  - Only works for the death from falling.
- Teleports player to where player was last grounded 10 frames ago.
  - Needed to prevent player respawning on the edge of the tile.

## Remarks:
- To be revisited once a proper `Checkpoint` system is implemented.

## Recording:

https://github.com/KrillOrBeKrilled/GMTK-2023/assets/16372290/ce6fc87f-31a1-4268-b23c-ed15baa6ce71

