### PR TITLE
Swinging Axe Trap "Unfreed" Tiles Bug Fix

### DIFF
--- a/Assets/Code/Scripts/Player/TrapController.cs
+++ b/Assets/Code/Scripts/Player/TrapController.cs
@@ -224,8 +224,8 @@ namespace KrillOrBeKrilled.Player {
             // Validate the deployment of the trap with a validation score
             var isDeployable = true;
             foreach (var gridOffsetPosition in prefabPoints) {
-                if (gridOffsetPosition.IsTrapTile != 
-                    IsTileOfType<TrapTile>(this.TrapTilemap, deploymentOrigin + gridOffsetPosition.GridPosition)) {
+                if (gridOffsetPosition.IsTrapTile && 
+                    gridOffsetPosition.IsTrapTile != IsTileOfType<TrapTile>(this.TrapTilemap, deploymentOrigin + gridOffsetPosition.GridPosition)) {
                     isDeployable = false;
                 }
     


### PR DESCRIPTION
## Changes:
- Made adjustments to the `TrapController` trap surveying to only check for `TrapTile` equality instead of comparing all tile types for equality
  - The axe trap did successfully "free" the occupied tiles via the `TilemapManager`, but "freeing" sets all occupied tile types to `TrapTile`, which caused the axe trap to invalidate as it was checking for matches on specific tile types per unit 